### PR TITLE
Increase memory requirements for kat hist

### DIFF
--- a/reflow/kat.rf
+++ b/reflow/kat.rf
@@ -5,7 +5,7 @@ val kat = "quay.io/biocontainers/kat:2.4.0--py36h355e19c_3"
 
 val dirs = make("$/dirs")
 
-threads := 16
+threads := 8
 
 // Kmer histogram
 func Hist(reads file, id string, ksize int) = {
@@ -15,11 +15,11 @@ func Hist(reads file, id string, ksize int) = {
     // Ensure input file has fastq.gz ending
     d := dirs.Make([id+".fastq.gz": reads])
 
-    exec(image := kat, cpu := threads, mem := 244*GiB) (outdir dir) {"
+    exec(image := kat, cpu := threads, mem := 240*GiB) (outdir dir) {"
         cd {{outdir}}
         kat hist --mer_len {{ksize}} \
             --threads {{threads}} \
-            --hash_size 10000000000 \
+            --hash_size 10000000000000000 \
             --output_prefix {{id}}.kat.hist {{d}}/{{id}}.fastq.gz
     "}
 }

--- a/reflow/kat.rf
+++ b/reflow/kat.rf
@@ -15,7 +15,7 @@ func Hist(reads file, id string, ksize int) = {
     // Ensure input file has fastq.gz ending
     d := dirs.Make([id+".fastq.gz": reads])
 
-    exec(image := kat, cpu := threads, mem := 128*GiB) (outdir dir) {"
+    exec(image := kat, cpu := threads, mem := 244*GiB) (outdir dir) {"
         cd {{outdir}}
         kat hist --mer_len {{ksize}} \
             --threads {{threads}} \


### PR DESCRIPTION
Getting an error with running kat hist using the large hash size


```
        quay.io/biocontainers/kat:2.4.0--py36h355e19c_3
        command:
            cd {{outdir}}
            kat hist --mer_len 32 \
                --threads 16 \
                --hash_size 10000000000 \
                --output_prefix tick_2_S2_R1_post-trimming.kat.hist {{d}}/tick_2_S2_R1_post-trimming.fastq.gz
        where:
            {{d}} = 
                tick_2_S2_R1_post-trimming.fastq.gz sha256:b58a1d649b492c01eed7346be373714f8e2d7e60120d32dfcf2f41000427c001 133.7GiB
        stdout:
            Kmer Analysis Toolkit (KAT) V2.4.0
            
            Running KAT in HIST mode
            ------------------------
            
            Input 1 is a sequence file.  Counting kmers for input 1 (/arg/1/0/tick_2_S2_R1_post-trimming.fastq.gz) ...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
            Warning: Specified hash size insufficent - attempting to double hash size...
        stderr:
            ../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h:../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h:../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h:../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h:../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h368:368../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h FAILED! 368 (:../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h:368../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h:::: FAILED!  FAILED! : (368368Uncaught exception of type std::runtime_error: Hash full FAILED!  FAILED!  (::: FAILED! 368Uncaught exception of type std::runtime_error: Hash full368368 ( FAILED! 368368 FAILED!  (Uncaught exception of type std::runtime_error: Hash fullUncaught exception of type std::runtime_error: Hash full) FAILED!  () (
            )368 FAILED! ../deps/seqan-library-2.0.0/include/seqan/basic/basic_exception.h (368 ()Uncaught exception of type std::runtime_error: Hash full ()368
```