### PR TITLE
Add SPAdes assembler

### DIFF
--- a/reflow/Makefile
+++ b/reflow/Makefile
@@ -76,3 +76,25 @@ test_quast:
 		-fastas 's3://tick-genome/dna/2018-10-10-dovetail/ixodes_scapularis_06May2018_kaVVW.fasta.gz|s3://tick-genome/dna/2018-10-11_ise6_asm2.2/GCA_002892825.2_ISE6_asm2.2_deduplicated_genomic.fna.gz' \
 		-ids 'dovetail_2018-05-06|jcvi_ise6' \
 		-output 's3://tick-genome/dna/2018-12-03_quast/'
+
+
+test_spades_uncorrected:
+	reflow run assemble_illumina.rf \
+		-read1=s3://tick-genome/dna/2018-06-28/tick_1_S1_R1_001_first1Mreads.fastq.gz \
+		-read2=s3://tick-genome/dna/2018-06-28/tick_1_S1_R2_001_first1Mreads.fastq.gz \
+		-name=tick_1_S1_first1Mreads \
+		-output=s3://tick-genome/dna/2018-06-28/assemble_spades_test_v1/ \
+		-corrected=False
+
+subset_corrected_reads:
+	aws s3 cp s3://tick-genome/dna/2018-06-28/pre-assembly_v3/tick_1_S1tick_1_S1_R1_post-trimming.fastq.gz - | zcat | head -n 4000000 | gzip -c | aws s3 cp - s3://tick-genome/dna/2018-06-28/tick_1_S1_R1_post-trimming_first1Mreads.fastq.gz
+	aws s3 cp s3://tick-genome/dna/2018-06-28/pre-assembly_v3/tick_1_S1tick_1_S1_R2_post-trimming.fastq.gz - | zcat | head -n 4000000 | gzip -c | aws s3 cp - s3://tick-genome/dna/2018-06-28/tick_1_S1_R2_post-trimming_first1Mreads.fastq.gz
+
+
+test_spades_corrected:
+	reflow run assemble_illumina.rf \
+		-read1=s3://tick-genome/dna/2018-06-28/tick_1_S1_R1_post-trimming_first1Mreads.fastq.gz \
+		-read2=s3://tick-genome/dna/2018-06-28/tick_1_S1_R2_post-trimming_first1Mreads.fastq.gz \
+		-name=tick_1_S1_first1Mreads \
+		-output=s3://tick-genome/dna/2018-06-28/assemble_spades_test_v1/ \
+		-corrected=False

--- a/reflow/assemble_illumina.rf
+++ b/reflow/assemble_illumina.rf
@@ -6,7 +6,10 @@ param (
     read2 string
 
     // name of the sample
-    id string
+    name string
+
+    // are the reads already error-corrected?
+    corrected bool
 
     // S3 folder to put the assembly
     output string
@@ -14,16 +17,14 @@ param (
 
 
 val dirs = make("$/dirs")
-
-
-val adapter_removal = make("./adapter_removal.rf")
-val fastqc = make("./fastqc.rf")
-val bbduk = make("./bbduk.rf")
-val idseq = make("./idseq.rf")
-val kat = make("./kat.rf")
+val spades = make("./spades.rf")
 
 
 val r1 = file(read1)
 val r2 = file(read2)
 
 
+val spades_output = spades.AssembleIllumina(
+    r1, r2, name, corrected)
+
+val Main = dirs.Copy(spades_output, output)

--- a/reflow/spades.rf
+++ b/reflow/spades.rf
@@ -1,0 +1,31 @@
+
+param (
+    threads = 32
+)
+
+
+// SPAdes – St. Petersburg genome assembler – is an assembly toolkit 
+// containing various assembly pipelines. This manual will help you to install and run SPAdes. 
+// SPAdes version 3.11.1 was released under GPLv2 on October 1, 2017 and can be downloaded from http://cab.spbu.ru/software/spades/.
+// http://spades.bioinf.spbau.ru/release3.11.1/manual.html
+val spades = "quay.io/biocontainers/spades:3.13.0--0"
+
+val dirs = make("$/dirs")
+val fastp = make("./fastp.rf")
+val utils = make("./utils.rf")
+
+
+func AssembleIllumina(r1, r2 file, id string, corrected bool) = {
+
+    // If using corrected reads, don't use SPAdes internal correction algorithms
+    flags := if (corrected) {
+        "--only-assembler"
+    } else {
+        ""
+    }
+
+    exec(image := spades, cpu := threads, mem := 450*GiB) (outdir dir) {"
+        cd {{outdir}}
+        spades.py -k 21,33,55,77 --careful {{flags}} -1 {{r1}} -2 {{r2}} -o {{id}}_spades
+    "}
+}

--- a/reflow/spades.rf
+++ b/reflow/spades.rf
@@ -24,8 +24,13 @@ func AssembleIllumina(r1, r2 file, id string, corrected bool) = {
         ""
     }
 
+    d := make([id + "_R1.fastq.gz": r1, id + "_R2.fastq.gz": r2])
+
     exec(image := spades, cpu := threads, mem := 450*GiB) (outdir dir) {"
         cd {{outdir}}
-        spades.py -k 21,33,55,77 --careful {{flags}} -1 {{r1}} -2 {{r2}} -o {{id}}_spades
+        spades.py -k 21,33,55,77 --careful {{flags}} \
+            -1 {{d}}/{{id}}_R1.fastq.gz \
+            -2 {{d}}/{{id}}_R2.fastq.gz \
+            -o {{id}}_spades
     "}
 }

--- a/reflow/spades.rf
+++ b/reflow/spades.rf
@@ -24,7 +24,7 @@ func AssembleIllumina(r1, r2 file, id string, corrected bool) = {
         ""
     }
 
-    d := make([id + "_R1.fastq.gz": r1, id + "_R2.fastq.gz": r2])
+    d := dirs.Make([id + "_R1.fastq.gz": r1, id + "_R2.fastq.gz": r2])
 
     exec(image := spades, cpu := threads, mem := 450*GiB) (outdir dir) {"
         cd {{outdir}}


### PR DESCRIPTION
http://spades.bioinf.spbau.ru/release3.11.1/manual.html#sec3.4

Originally meant for bacterial genomes, but [successfully used for *Drosophila*](https://www.ncbi.nlm.nih.gov/pubmed/30423125). Though *Drosophila* is ~150 Mb and *Ixodes* is ~2.5 Gb, still could be useful to try out